### PR TITLE
[#24] 검색 api 버그 수정

### DIFF
--- a/api/src/main/java/com/grayzone/domain/company/dto/response/CompaniesSearchResponseDto.java
+++ b/api/src/main/java/com/grayzone/domain/company/dto/response/CompaniesSearchResponseDto.java
@@ -4,10 +4,10 @@ import com.grayzone.domain.company.repository.projection.CompanySearchOnly;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 @Getter
@@ -66,10 +66,9 @@ public class CompaniesSearchResponseDto {
         .id(company.getId())
         .companyName(company.getCompanyName())
         .companyAddress(
-          Objects.requireNonNullElse(
-            company.getSiteFullAddress(),
-            company.getRoadNameAddress()
-          )
+          StringUtils.hasText(company.getSiteFullAddress())
+            ? company.getSiteFullAddress()
+            : company.getRoadNameAddress()
         )
         .reviewTitle(reviewTitle)
         .totalRating(totalRating)

--- a/api/src/main/java/com/grayzone/domain/company/dto/response/CompaniesSuggestResponseDto.java
+++ b/api/src/main/java/com/grayzone/domain/company/dto/response/CompaniesSuggestResponseDto.java
@@ -4,10 +4,10 @@ import com.grayzone.domain.company.repository.projection.CompanySuggestionOnly;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.Slice;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 @Getter
 @Builder
@@ -52,10 +52,9 @@ public class CompaniesSuggestResponseDto {
         .id(company.getId())
         .companyName(company.getCompanyName())
         .companyAddress(
-          Objects.requireNonNullElse(
-            company.getSiteFullAddress(),
-            company.getRoadNameAddress()
-          )
+          StringUtils.hasText(company.getSiteFullAddress())
+            ? company.getSiteFullAddress()
+            : company.getRoadNameAddress()
         )
         .totalRating(totalRating)
         .build();

--- a/api/src/main/java/com/grayzone/domain/company/repository/CompanyRepository.java
+++ b/api/src/main/java/com/grayzone/domain/company/repository/CompanyRepository.java
@@ -79,7 +79,7 @@ public interface CompanyRepository extends JpaRepository<Company, Long> {
     LEFT JOIN company_reviews r ON r.company_id = c.id
     WHERE c.site_full_address LIKE :region
     GROUP BY c.id, c.business_name, c.site_full_address, c.road_name_address
-    ORDER BY COUNT(r.id) DESC, distance ASC
+    ORDER BY (c.latitude IS NULL OR c.longitude IS NULL) ASC, COUNT(r.id) DESC, distance ASC, c.id ASC
     """, nativeQuery = true)
   Page<CompanySearchOnly> findCompaniesByRegion(
     @Param("latitude") Double latitude,

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -6,7 +6,6 @@ spring.datasource.password=${DATABASE_PASSWORD}
 spring.docker.compose.lifecycle-management=start-and-stop
 # JPA
 spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=${SHOW_SQL}
 # Pagination
 spring.data.web.pageable.default-page-size=10
 spring.data.web.pageable.max-page-size=10


### PR DESCRIPTION
## 🔍 관련 GitHub 이슈

- closed #24

## 📝 변경 사항

- 검색 api 주소 누락문제 해결 (siteFullAddress가 null이 아니라 빈 공백으로 들어가서 roadNameAddress로 대체가 안되는 문제)
 - 페이지네이션 중복 문제 해결 (정렬 기준이 명확하지 않아서 쿼리마다 결과가 달라지는 문제)

## 📸 스크린샷

## ✅ PR 체크리스트

- [x] 커밋 메시지에 GitHub 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] GitHub 이슈 상태 업데이트

## 📌 참고 사항
- 
