### PR TITLE
[#28] 주소 검색 api 구현

### DIFF
--- a/api/src/main/java/com/grayzone/domain/legaldistrict/controller/LegalDistrictController.java
+++ b/api/src/main/java/com/grayzone/domain/legaldistrict/controller/LegalDistrictController.java
@@ -1,0 +1,32 @@
+package com.grayzone.domain.legaldistrict.controller;
+
+import com.grayzone.common.ResponseDataDto;
+import com.grayzone.domain.legaldistrict.dto.LegalDistrictsResponseDto;
+import com.grayzone.domain.legaldistrict.service.LegalDistrictService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/api/legal-districts")
+@RequiredArgsConstructor
+public class LegalDistrictController {
+  private final LegalDistrictService legalDistrictService;
+
+  @GetMapping
+  public ResponseEntity<ResponseDataDto<LegalDistrictsResponseDto>> searchLegalDistricts(
+    @RequestParam("keyword") String keyword,
+    Pageable pageable
+  ) {
+    return ResponseEntity.ok(
+      ResponseDataDto.from(
+        legalDistrictService.getSearchedLegalDistricts(keyword, pageable)
+      )
+    );
+  }
+}

--- a/api/src/main/java/com/grayzone/domain/legaldistrict/dto/LegalDistrictsResponseDto.java
+++ b/api/src/main/java/com/grayzone/domain/legaldistrict/dto/LegalDistrictsResponseDto.java
@@ -3,23 +3,21 @@ package com.grayzone.domain.legaldistrict.dto;
 import com.grayzone.domain.legaldistrict.repository.projection.LegalDistrictPrefixOnly;
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
 @Getter
 @Builder
 public class LegalDistrictsResponseDto {
-  private long totalCount;
   private boolean hasNext;
   private int currentPage;
   private List<LegalDistrictResponseDto> legalDistricts;
 
-  public static LegalDistrictsResponseDto from(Page<LegalDistrictPrefixOnly> legalDistricts) {
+  public static LegalDistrictsResponseDto from(Slice<LegalDistrictPrefixOnly> legalDistricts) {
     List<LegalDistrictResponseDto> legalDistrictResponseDtos = legalDistricts.getContent().stream().map(LegalDistrictResponseDto::from)
       .toList();
     return LegalDistrictsResponseDto.builder()
-      .totalCount(legalDistricts.getTotalElements())
       .hasNext(legalDistricts.hasNext())
       .currentPage(legalDistricts.getNumber())
       .legalDistricts(legalDistrictResponseDtos)

--- a/api/src/main/java/com/grayzone/domain/legaldistrict/dto/LegalDistrictsResponseDto.java
+++ b/api/src/main/java/com/grayzone/domain/legaldistrict/dto/LegalDistrictsResponseDto.java
@@ -1,0 +1,42 @@
+package com.grayzone.domain.legaldistrict.dto;
+
+import com.grayzone.domain.legaldistrict.repository.projection.LegalDistrictPrefixOnly;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class LegalDistrictsResponseDto {
+  private long totalCount;
+  private boolean hasNext;
+  private int currentPage;
+  private List<LegalDistrictResponseDto> legalDistricts;
+
+  public static LegalDistrictsResponseDto from(Page<LegalDistrictPrefixOnly> legalDistricts) {
+    List<LegalDistrictResponseDto> legalDistrictResponseDtos = legalDistricts.getContent().stream().map(LegalDistrictResponseDto::from)
+      .toList();
+    return LegalDistrictsResponseDto.builder()
+      .totalCount(legalDistricts.getTotalElements())
+      .hasNext(legalDistricts.hasNext())
+      .currentPage(legalDistricts.getNumber())
+      .legalDistricts(legalDistrictResponseDtos)
+      .build();
+  }
+
+  @Getter
+  @Builder
+  public static class LegalDistrictResponseDto {
+    private long id;
+    private String name;
+
+    public static LegalDistrictResponseDto from(LegalDistrictPrefixOnly legalDistrict) {
+      return LegalDistrictResponseDto.builder()
+        .id(legalDistrict.getId())
+        .name(legalDistrict.getLegalDistrict())
+        .build();
+    }
+  }
+}

--- a/api/src/main/java/com/grayzone/domain/legaldistrict/entity/LegalDistrict.java
+++ b/api/src/main/java/com/grayzone/domain/legaldistrict/entity/LegalDistrict.java
@@ -1,0 +1,24 @@
+package com.grayzone.domain.legaldistrict.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "legal_districts")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class LegalDistrict {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String address;
+
+  @Builder
+  public LegalDistrict(String address) {
+    this.address = address;
+  }
+}

--- a/api/src/main/java/com/grayzone/domain/legaldistrict/repository/LegalDistrictRepository.java
+++ b/api/src/main/java/com/grayzone/domain/legaldistrict/repository/LegalDistrictRepository.java
@@ -3,11 +3,10 @@ package com.grayzone.domain.legaldistrict.repository;
 import com.grayzone.domain.legaldistrict.entity.LegalDistrict;
 import com.grayzone.domain.legaldistrict.repository.projection.LegalDistrictPrefixOnly;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface LegalDistrictRepository extends JpaRepository<LegalDistrict, Long> {
   @Query(value = """
@@ -16,7 +15,7 @@ public interface LegalDistrictRepository extends JpaRepository<LegalDistrict, Lo
         WHERE ld.address LIKE %:keyword%
         GROUP BY legal_district, id
     """, nativeQuery = true)
-  List<LegalDistrictPrefixOnly> findLegalDistrictByKeyword(
+  Slice<LegalDistrictPrefixOnly> findLegalDistrictByKeyword(
     @Param("keyword") String keyword,
     Pageable pageable
   );

--- a/api/src/main/java/com/grayzone/domain/legaldistrict/repository/LegalDistrictRepository.java
+++ b/api/src/main/java/com/grayzone/domain/legaldistrict/repository/LegalDistrictRepository.java
@@ -1,8 +1,23 @@
 package com.grayzone.domain.legaldistrict.repository;
 
 import com.grayzone.domain.legaldistrict.entity.LegalDistrict;
+import com.grayzone.domain.legaldistrict.repository.projection.LegalDistrictPrefixOnly;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface LegalDistrictRepository extends JpaRepository<LegalDistrict, Long> {
-
+  @Query(value = """
+        SELECT ld.id, SUBSTRING_INDEX(ld.address, ' ', 3) AS legal_district
+        FROM legal_districts ld
+        WHERE ld.address LIKE %:keyword%
+        GROUP BY legal_district, id
+    """, nativeQuery = true)
+  List<LegalDistrictPrefixOnly> findLegalDistrictByKeyword(
+    @Param("keyword") String keyword,
+    Pageable pageable
+  );
 }

--- a/api/src/main/java/com/grayzone/domain/legaldistrict/repository/LegalDistrictRepository.java
+++ b/api/src/main/java/com/grayzone/domain/legaldistrict/repository/LegalDistrictRepository.java
@@ -1,0 +1,8 @@
+package com.grayzone.domain.legaldistrict.repository;
+
+import com.grayzone.domain.legaldistrict.entity.LegalDistrict;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LegalDistrictRepository extends JpaRepository<LegalDistrict, Long> {
+
+}

--- a/api/src/main/java/com/grayzone/domain/legaldistrict/repository/projection/LegalDistrictPrefixOnly.java
+++ b/api/src/main/java/com/grayzone/domain/legaldistrict/repository/projection/LegalDistrictPrefixOnly.java
@@ -1,0 +1,7 @@
+package com.grayzone.domain.legaldistrict.repository.projection;
+
+public interface LegalDistrictPrefixOnly {
+  long getId();
+
+  String getLegalDistrict();
+}

--- a/api/src/main/java/com/grayzone/domain/legaldistrict/service/LegalDistrictService.java
+++ b/api/src/main/java/com/grayzone/domain/legaldistrict/service/LegalDistrictService.java
@@ -1,7 +1,9 @@
 package com.grayzone.domain.legaldistrict.service;
 
+import com.grayzone.domain.legaldistrict.dto.LegalDistrictsResponseDto;
 import com.grayzone.domain.legaldistrict.repository.LegalDistrictRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,5 +13,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class LegalDistrictService {
   private final LegalDistrictRepository legalDistrictRepository;
 
-  
+  public LegalDistrictsResponseDto getSearchedLegalDistricts(String keyword, Pageable pageable) {
+    return LegalDistrictsResponseDto.from(
+      legalDistrictRepository.findLegalDistrictByKeyword(keyword, pageable)
+    );
+  }
 }

--- a/api/src/main/java/com/grayzone/domain/legaldistrict/service/LegalDistrictService.java
+++ b/api/src/main/java/com/grayzone/domain/legaldistrict/service/LegalDistrictService.java
@@ -1,0 +1,15 @@
+package com.grayzone.domain.legaldistrict.service;
+
+import com.grayzone.domain.legaldistrict.repository.LegalDistrictRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class LegalDistrictService {
+  private final LegalDistrictRepository legalDistrictRepository;
+
+  
+}

--- a/api/src/main/java/com/grayzone/global/gemini/GeminiReviewTitleSummarizer.java
+++ b/api/src/main/java/com/grayzone/global/gemini/GeminiReviewTitleSummarizer.java
@@ -20,11 +20,9 @@ public class GeminiReviewTitleSummarizer implements ReviewTitleSummarizer {
       .build();
   }
 
-
   @Override
   public String summarize(String body) {
     String summarizeSource = body + GeminiConst.SUMMARY_PROMPT;
-    log.info("summarizeSource: {}", summarizeSource);
 
     GeminiSummarizeRequest request = new GeminiSummarizeRequest(summarizeSource);
 

--- a/api/src/main/java/com/grayzone/setup/legaldistrict/LegalDistrictApiClient.java
+++ b/api/src/main/java/com/grayzone/setup/legaldistrict/LegalDistrictApiClient.java
@@ -1,0 +1,30 @@
+package com.grayzone.setup.legaldistrict;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class LegalDistrictApiClient {
+  private final RestClient restClient;
+  private final LegalDistrictApiProperties properties;
+
+  public LegalDistrictApiClient(LegalDistrictApiProperties properties) {
+    this.properties = properties;
+    this.restClient = RestClient.builder()
+      .baseUrl(properties.getBaseUrl())
+      .build();
+  }
+
+  public LegalDistrictsApiResponse getAllLegalDistricts(int page, int perPage) {
+    return restClient.get()
+      .uri(uriBuilder -> uriBuilder
+        .path(properties.getPath())
+        .queryParam("page", page)
+        .queryParam("perPage", perPage)
+        .build()
+      )
+      .header("Authorization", properties.getKey())
+      .retrieve()
+      .body(LegalDistrictsApiResponse.class);
+  }
+}

--- a/api/src/main/java/com/grayzone/setup/legaldistrict/LegalDistrictApiProperties.java
+++ b/api/src/main/java/com/grayzone/setup/legaldistrict/LegalDistrictApiProperties.java
@@ -1,0 +1,16 @@
+package com.grayzone.setup.legaldistrict;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "legal.district.api")
+public class LegalDistrictApiProperties {
+  private String baseUrl;
+  private String path;
+  private String key;
+}

--- a/api/src/main/java/com/grayzone/setup/legaldistrict/LegalDistrictSetupController.java
+++ b/api/src/main/java/com/grayzone/setup/legaldistrict/LegalDistrictSetupController.java
@@ -1,0 +1,18 @@
+package com.grayzone.setup.legaldistrict;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class LegalDistrictSetupController {
+  private final LegalDistrictSetupService legalDistrictSetupService;
+
+  @GetMapping("legal-districts/setup")
+  public void setupLegalDistricts() {
+    legalDistrictSetupService.setupLegalDistricts();
+  }
+}

--- a/api/src/main/java/com/grayzone/setup/legaldistrict/LegalDistrictSetupService.java
+++ b/api/src/main/java/com/grayzone/setup/legaldistrict/LegalDistrictSetupService.java
@@ -1,0 +1,49 @@
+package com.grayzone.setup.legaldistrict;
+
+import com.grayzone.domain.legaldistrict.entity.LegalDistrict;
+import com.grayzone.domain.legaldistrict.repository.LegalDistrictRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LegalDistrictSetupService {
+  private final LegalDistrictRepository legalDistrictRepository;
+  private final LegalDistrictApiClient legalDistrictApiClient;
+
+  @Transactional
+  public void setupLegalDistricts() {
+    int currentPage = 1;
+    int perPage = 3000;
+    int totalCount = 0;
+
+    do {
+      LegalDistrictsApiResponse legalDistrictsApiResponse = legalDistrictApiClient.getAllLegalDistricts(currentPage, perPage);
+      totalCount = legalDistrictsApiResponse.getTotalCount();
+      currentPage++;
+
+      legalDistrictsApiResponse.getData().stream()
+        .filter(legalDistrict -> legalDistrict.getDeletedDate() == null)
+        .filter(ld -> ld.getProvince() != null && ld.getCity() != null && ld.getTown() != null)
+        .map(legalDistrict -> {
+          String address = Stream.of(
+              legalDistrict.getProvince(),
+              legalDistrict.getCity(),
+              legalDistrict.getTown(),
+              legalDistrict.getVillage()
+            )
+            .filter(Objects::nonNull)
+            .collect(Collectors.joining(" "));
+          return new LegalDistrict(address);
+        }).forEach(legalDistrictRepository::save);
+
+    } while (currentPage * perPage < totalCount);
+  }
+}

--- a/api/src/main/java/com/grayzone/setup/legaldistrict/LegalDistrictsApiResponse.java
+++ b/api/src/main/java/com/grayzone/setup/legaldistrict/LegalDistrictsApiResponse.java
@@ -1,0 +1,39 @@
+package com.grayzone.setup.legaldistrict;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class LegalDistrictsApiResponse {
+  private int page;
+  private int perPage;
+  private int totalCount;
+  private int currentCount;
+  private List<LegalDistrictApiResponse> data;
+
+  @Getter
+  @Setter
+  static class LegalDistrictApiResponse {
+    @JsonProperty("시도명")
+    private String province;
+
+    @JsonProperty("시군구명")
+    private String city;
+
+    @JsonProperty("읍면동명")
+    private String town;
+
+    @JsonProperty("리명")
+    private String village;
+
+    @JsonProperty("생성일자")
+    private String createdDate;
+
+    @JsonProperty("삭제일자")
+    private String deletedDate;
+  }
+}

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -6,12 +6,13 @@ spring.datasource.password=${DATABASE_PASSWORD}
 spring.docker.compose.lifecycle-management=start-and-stop
 # JPA
 spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=${SHOW_SQL}
 # Pagination
 spring.data.web.pageable.default-page-size=10
 spring.data.web.pageable.max-page-size=10
 # Gemini
 gemini.key=${GEMINI_KEY}
 # Public API
-legal.district.api.base- url=https://api.odcloud.kr/api
+legal.district.api.base-url=https://api.odcloud.kr/api
 legal.district.api.path=/15063424/v1/uddi:6d7fd177-cc7d-426d-ba80-9b137edf6066
 legal.district.api.key=${LEGAL_DISTRICT_API_KEY}

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -11,3 +11,7 @@ spring.data.web.pageable.default-page-size=10
 spring.data.web.pageable.max-page-size=10
 # Gemini
 gemini.key=${GEMINI_KEY}
+# Public API
+legal.district.api.base- url=https://api.odcloud.kr/api
+legal.district.api.path=/15063424/v1/uddi:6d7fd177-cc7d-426d-ba80-9b137edf6066
+legal.district.api.key=${LEGAL_DISTRICT_API_KEY}

--- a/api/src/test/java/com/grayzone/legaldistrict/repository/LegalDistrictRepositoryTest.java
+++ b/api/src/test/java/com/grayzone/legaldistrict/repository/LegalDistrictRepositoryTest.java
@@ -1,0 +1,32 @@
+package com.grayzone.legaldistrict.repository;
+
+import com.grayzone.domain.legaldistrict.repository.LegalDistrictRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
+
+@Slf4j
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = NONE)
+public class LegalDistrictRepositoryTest {
+
+  @Autowired
+  private LegalDistrictRepository legalDistrictRepository;
+
+  @Test
+  public void findLegalDistrictsByKeyword() {
+    String keyword = "기장군";
+    Pageable pageable = PageRequest.of(0, 10);
+
+    legalDistrictRepository.findLegalDistrictByKeyword(keyword, pageable).stream()
+      .forEach(legalDistrict -> {
+        log.info(legalDistrict.getLegalDistrict());
+      });
+  }
+}


### PR DESCRIPTION
## 🔍 관련 GitHub 이슈

- closed #28 

## 📝 변경 사항
- 법정동 공공 api 연동, db insert(최적화 필요)
- 법정동 검색 로직 구현

## 📸 스크린샷

## ✅ PR 체크리스트

- [x] 커밋 메시지에 GitHub 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] GitHub 이슈 상태 업데이트

## 📌 참고 사항
- 검색 기획 수정필요해보임.(~~리 불필요)
