### PR TITLE
[#37] docker compose cache-network 명령어 추가

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -42,6 +42,7 @@ services:
       - .env.local
     networks:
       - db-network
+      - cache-network
     depends_on:
       mysql:
         condition: service_healthy


### PR DESCRIPTION
## 🔍 관련 GitHub 이슈

- closed #37 

## 📝 변경 사항
- redis 컨테이너와 WAS 컨테이너 간의 연결을 위한 네트워크 명령어 추가

## 📸 스크린샷

## ✅ PR 체크리스트

- [x] 커밋 메시지에 GitHub 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] GitHub 이슈 상태 업데이트

## 📌 참고 사항

- 
