### PR TITLE
[#55] 회원탈퇴 api oauth 연결끊기 추가

### DIFF
--- a/api/src/main/java/com/grayzone/GrayzoneApplication.java
+++ b/api/src/main/java/com/grayzone/GrayzoneApplication.java
@@ -8,8 +8,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @SpringBootApplication
 public class GrayzoneApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(GrayzoneApplication.class, args);
-	}
+  public static void main(String[] args) {
+    SpringApplication.run(GrayzoneApplication.class, args);
+  }
 
 }

--- a/api/src/main/java/com/grayzone/domain/auth/controller/AuthController.java
+++ b/api/src/main/java/com/grayzone/domain/auth/controller/AuthController.java
@@ -1,7 +1,6 @@
 package com.grayzone.domain.auth.controller;
 
 import com.grayzone.common.ResponseDataDto;
-import com.grayzone.domain.auth.dto.request.LoginRequestDto;
 import com.grayzone.domain.auth.dto.request.LogoutRequestDto;
 import com.grayzone.domain.auth.dto.request.ReissueRequestDto;
 import com.grayzone.domain.auth.dto.request.SignUpRequestDto;
@@ -15,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
 import java.util.stream.Stream;
 
 @RestController
@@ -39,11 +39,11 @@ public class AuthController {
 
   @PostMapping("/login")
   public ResponseEntity<ResponseDataDto<LoginResponseDto>> login(
-    @Valid @RequestBody LoginRequestDto requestDto
+    @RequestBody Map<String, String> requestMap
   ) {
     return ResponseEntity.ok(
       ResponseDataDto.from(
-        authService.login(requestDto)
+        authService.login(requestMap)
       )
     );
   }
@@ -53,7 +53,7 @@ public class AuthController {
     @RequestBody LogoutRequestDto requestDto
   ) {
     authService.logout(requestDto.getRefreshToken());
-    
+
     return ResponseEntity.ok(
       ResponseDataDto.from(
         null

--- a/api/src/main/java/com/grayzone/domain/auth/dto/request/SignUpRequestDto.java
+++ b/api/src/main/java/com/grayzone/domain/auth/dto/request/SignUpRequestDto.java
@@ -4,6 +4,7 @@ import com.grayzone.domain.legaldistrict.entity.LegalDistrict;
 import com.grayzone.domain.user.UserTerm;
 import com.grayzone.domain.user.entity.User;
 import com.grayzone.global.oauth.OAuthProvider;
+import com.grayzone.global.oauth.OAuthUserInfo;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -36,13 +37,14 @@ public class SignUpRequestDto {
 
   private List<UserTerm> agreements;
 
-  public User toEntity(String email, LegalDistrict mainRegion) {
+  public User toEntity(OAuthUserInfo oAuthUserInfo, LegalDistrict mainRegion) {
     validateAgreements(agreements);
 
     return User.builder()
-      .email(email)
+      .email(oAuthUserInfo.getEmail())
       .nickname(nickname)
-      .oAuthProvider(oauthProvider)
+      .oAuthProvider(oAuthUserInfo.getProvider())
+      .oAuthId(oAuthUserInfo.getOAuthId())
       .mainRegion(mainRegion)
       .agreedServiceUse(true)
       .agreedPrivacy(true)

--- a/api/src/main/java/com/grayzone/domain/auth/service/AuthService.java
+++ b/api/src/main/java/com/grayzone/domain/auth/service/AuthService.java
@@ -44,7 +44,7 @@ public class AuthService {
 
     OAuthUserInfo userInfo = oAuthUserInfoDispatcher.dispatch(requestDto.getOauthProvider(), requestDto.getOauthToken());
 
-    User user = requestDto.toEntity(userInfo.getEmail(), mainRegion);
+    User user = requestDto.toEntity(userInfo, mainRegion);
     List<InterestedRegion> interestedRegions = new ArrayList<>();
 
     if (!requestDto.getInterestedRegionIds().isEmpty()) {
@@ -60,7 +60,7 @@ public class AuthService {
   public LoginResponseDto login(LoginRequestDto requestDto) {
     OAuthUserInfo userInfo = oAuthUserInfoDispatcher.dispatch(requestDto.getOauthProvider(), requestDto.getOauthToken());
 
-    User user = userRepository.findByEmail(userInfo.getEmail())
+    User user = userRepository.findByoAuthId(userInfo.getOAuthId())
       .orElseThrow(() -> new UpException(UpError.UNAUTHORIZED_USER));
 
     TokenPair tokenPair = tokenManager.createTokenPair(user.getId());

--- a/api/src/main/java/com/grayzone/domain/auth/service/AuthService.java
+++ b/api/src/main/java/com/grayzone/domain/auth/service/AuthService.java
@@ -13,8 +13,8 @@ import com.grayzone.global.exception.UpException;
 import com.grayzone.global.oauth.OAuthProvider;
 import com.grayzone.global.oauth.OAuthUserInfo;
 import com.grayzone.global.oauth.OAuthUserInfoDispatcher;
-import com.grayzone.global.oauth.apple.AppleGenerateTokenResponseDto;
 import com.grayzone.global.oauth.apple.AppleOAuthTokenGenerator;
+import com.grayzone.global.oauth.apple.AppleTokenResponse;
 import com.grayzone.global.token.TokenManager;
 import com.grayzone.global.token.TokenPair;
 import lombok.RequiredArgsConstructor;
@@ -83,7 +83,7 @@ public class AuthService {
       .orElseThrow(() -> new UpException(UpError.UNAUTHORIZED_USER));
 
     if (user.requiresAppleRefreshToken()) {
-      AppleGenerateTokenResponseDto appleToken = oAuthTokenGenerator.generateAppleToken(authorizationCode);
+      AppleTokenResponse appleToken = oAuthTokenGenerator.generateAppleToken(authorizationCode);
       user.setOAuthRefreshToken(appleToken.getRefreshToken());
       userRepository.save(user);
     }

--- a/api/src/main/java/com/grayzone/domain/company/repository/CompanyRepository.java
+++ b/api/src/main/java/com/grayzone/domain/company/repository/CompanyRepository.java
@@ -98,9 +98,9 @@ public interface CompanyRepository extends JpaRepository<Company, Long> {
         )) AS distance
     FROM companies c
     LEFT JOIN company_reviews r ON r.company_id = c.id
-    WHERE (:address1 IS NULL OR c.site_full_address LIKE :address1)
-        OR (:address2 IS NULL OR c.site_full_address LIKE :address2)
-        OR (:address3 IS NULL OR c.site_full_address LIKE :address3)
+    WHERE (:address1 IS NOT NULL AND c.site_full_address LIKE :address1)
+        OR (:address2 IS NOT NULL AND c.site_full_address LIKE :address2)
+        OR (:address3 IS NOT NULL AND c.site_full_address LIKE :address3)
     GROUP BY c.id, c.business_name, c.site_full_address, c.road_name_address
     ORDER BY (c.latitude IS NULL OR c.longitude IS NULL) ASC, distance ASC, COUNT(r.id) DESC, c.id ASC
     """, nativeQuery = true)

--- a/api/src/main/java/com/grayzone/domain/company/service/CompanyService.java
+++ b/api/src/main/java/com/grayzone/domain/company/service/CompanyService.java
@@ -148,14 +148,18 @@ public class CompanyService {
     String address2 = interestedRegionAddresses.size() > 1 ? interestedRegionAddresses.get(1) : null;
     String address3 = interestedRegionAddresses.size() > 2 ? interestedRegionAddresses.get(2) : null;
 
-    Page<CompanySearchOnly> companies = companyRepository.findCompaniesByRegion(
-      latitude,
-      longitude,
-      address1,
-      address2,
-      address3,
-      pageable
-    );
+    Page<CompanySearchOnly> companies = Page.empty(pageable);
+
+    if (!interestedRegionAddresses.isEmpty()) {
+      companies = companyRepository.findCompaniesByRegion(
+        latitude,
+        longitude,
+        address1,
+        address2,
+        address3,
+        pageable
+      );
+    }
 
     return buildCompaniesSearchResponseDto(companies, user);
   }

--- a/api/src/main/java/com/grayzone/domain/review/repository/CompanyReviewRepository.java
+++ b/api/src/main/java/com/grayzone/domain/review/repository/CompanyReviewRepository.java
@@ -61,9 +61,9 @@ public interface CompanyReviewRepository extends JpaRepository<CompanyReview, Lo
   @Query("""
     SELECT cr FROM CompanyReview cr
     LEFT JOIN cr.company c
-    WHERE (:address1 IS NULL OR c.siteFullAddress LIKE :address1)
-        OR (:address2 IS NULL OR c.siteFullAddress LIKE :address2)
-        OR (:address3 IS NULL OR c.siteFullAddress LIKE :address3)
+    WHERE (:address1 IS NOT NULL AND c.siteFullAddress LIKE :address1)
+        OR (:address2 IS NOT NULL AND c.siteFullAddress LIKE :address2)
+        OR (:address3 IS NOT NULL AND c.siteFullAddress LIKE :address3)
     ORDER BY cr.createdAt DESC
     """)
   Slice<CompanyReview> findCompanyReviewByInterestedRegions(

--- a/api/src/main/java/com/grayzone/domain/user/entity/User.java
+++ b/api/src/main/java/com/grayzone/domain/user/entity/User.java
@@ -51,6 +51,7 @@ public class User implements UserDetails {
     String email,
     String nickname,
     OAuthProvider oAuthProvider,
+    String oAuthId,
     LegalDistrict mainRegion,
     boolean agreedServiceUse,
     boolean agreedPrivacy,
@@ -59,6 +60,7 @@ public class User implements UserDetails {
     this.email = email;
     this.nickname = nickname;
     this.oAuthProvider = oAuthProvider;
+    this.oAuthId = oAuthId;
     this.mainRegion = mainRegion;
     this.agreedServiceUse = agreedServiceUse;
     this.agreedPrivacy = agreedPrivacy;

--- a/api/src/main/java/com/grayzone/domain/user/entity/User.java
+++ b/api/src/main/java/com/grayzone/domain/user/entity/User.java
@@ -22,7 +22,6 @@ public class User implements UserDetails {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false)
   private String email;
 
   @Column(unique = true, nullable = false)

--- a/api/src/main/java/com/grayzone/domain/user/entity/User.java
+++ b/api/src/main/java/com/grayzone/domain/user/entity/User.java
@@ -31,6 +31,8 @@ public class User implements UserDetails {
   @Enumerated(EnumType.STRING)
   private OAuthProvider oAuthProvider;
 
+  private String oAuthId;
+
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "main_region_id")
   private LegalDistrict mainRegion;

--- a/api/src/main/java/com/grayzone/domain/user/entity/User.java
+++ b/api/src/main/java/com/grayzone/domain/user/entity/User.java
@@ -31,6 +31,7 @@ public class User implements UserDetails {
   private OAuthProvider oAuthProvider;
 
   private String oAuthId;
+  private String oAuthRefreshToken;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "main_region_id")
@@ -89,5 +90,9 @@ public class User implements UserDetails {
   public void setInterestedRegions(List<InterestedRegion> interestedRegions) {
     this.interestedRegions.clear();
     this.interestedRegions.addAll(interestedRegions);
+  }
+
+  public boolean requiresAppleRefreshToken() {
+    return this.oAuthProvider == OAuthProvider.APPLE && this.oAuthRefreshToken == null;
   }
 }

--- a/api/src/main/java/com/grayzone/domain/user/entity/User.java
+++ b/api/src/main/java/com/grayzone/domain/user/entity/User.java
@@ -22,7 +22,7 @@ public class User implements UserDetails {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(unique = true, nullable = false)
+  @Column(nullable = false)
   private String email;
 
   @Column(unique = true, nullable = false)

--- a/api/src/main/java/com/grayzone/domain/user/repository/UserRepository.java
+++ b/api/src/main/java/com/grayzone/domain/user/repository/UserRepository.java
@@ -12,6 +12,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
   Optional<User> findByEmail(String email);
 
+  Optional<User> findByoAuthId(String oAuthId);
+
   @Query(value = """
     SELECT u FROM User u 
     JOIN FETCH u.mainRegion

--- a/api/src/main/java/com/grayzone/domain/user/service/UserService.java
+++ b/api/src/main/java/com/grayzone/domain/user/service/UserService.java
@@ -14,6 +14,7 @@ import com.grayzone.domain.user.repository.InterestedRegionRepository;
 import com.grayzone.domain.user.repository.UserRepository;
 import com.grayzone.global.exception.UpError;
 import com.grayzone.global.exception.UpException;
+import com.grayzone.global.oauth.OAuthRevokeDispatcher;
 import com.grayzone.global.token.TokenManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,6 +35,7 @@ public class UserService {
   private final CompanyRepository companyRepository;
   private final LegalDistrictRepository legalDistrictRepository;
   private final TokenManager tokenManager;
+  private final OAuthRevokeDispatcher oAuthRevokeDispatcher;
 
   public void verifyNicknameDuplicate(String nickname) {
     if (userRepository.existsByNickname(nickname)) {
@@ -93,6 +95,12 @@ public class UserService {
       tokenManager.invalidateRefreshToken(requestDto.getRefreshToken());
     } catch (Exception e) {
       log.warn("Refresh token invalidation failed", e);
+    }
+
+    try {
+      oAuthRevokeDispatcher.dispatch(user);
+    } catch (Exception e) {
+      log.warn("OAuth revoke dispatch failed", e);
     }
 
     userRepository.delete(deletedUser);

--- a/api/src/main/java/com/grayzone/global/oauth/OAuthProvider.java
+++ b/api/src/main/java/com/grayzone/global/oauth/OAuthProvider.java
@@ -1,6 +1,8 @@
 package com.grayzone.global.oauth;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.grayzone.global.exception.UpError;
+import com.grayzone.global.exception.UpException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -14,7 +16,7 @@ public enum OAuthProvider {
     return switch (name.toLowerCase()) {
       case "kakao" -> KAKAO;
       case "apple" -> APPLE;
-      default -> throw new IllegalArgumentException("Unknown OAuth provider: " + name);
+      default -> throw new UpException(UpError.OAUTH_UNSUPPORTED_PROVIDER);
     };
   }
 }

--- a/api/src/main/java/com/grayzone/global/oauth/OAuthRevokeDispatcher.java
+++ b/api/src/main/java/com/grayzone/global/oauth/OAuthRevokeDispatcher.java
@@ -1,0 +1,23 @@
+package com.grayzone.global.oauth;
+
+import com.grayzone.domain.user.entity.User;
+import com.grayzone.global.exception.UpError;
+import com.grayzone.global.exception.UpException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthRevokeDispatcher {
+  private final List<OAuthRevokeService> revokeServices;
+
+  public void dispatch(User user) {
+    revokeServices.stream()
+      .filter(revokeService -> revokeService.support(user.getOAuthProvider()))
+      .findFirst()
+      .orElseThrow(() -> new UpException(UpError.OAUTH_UNSUPPORTED_PROVIDER))
+      .revoke(user);
+  }
+}

--- a/api/src/main/java/com/grayzone/global/oauth/OAuthRevokeService.java
+++ b/api/src/main/java/com/grayzone/global/oauth/OAuthRevokeService.java
@@ -1,0 +1,9 @@
+package com.grayzone.global.oauth;
+
+import com.grayzone.domain.user.entity.User;
+
+public interface OAuthRevokeService {
+  boolean support(OAuthProvider provider);
+
+  void revoke(User user);
+}

--- a/api/src/main/java/com/grayzone/global/oauth/OAuthUserInfo.java
+++ b/api/src/main/java/com/grayzone/global/oauth/OAuthUserInfo.java
@@ -9,4 +9,5 @@ public class OAuthUserInfo {
 
   private OAuthProvider provider;
   private String email;
+  private String oAuthId;
 }

--- a/api/src/main/java/com/grayzone/global/oauth/apple/AppleGenerateTokenResponseDto.java
+++ b/api/src/main/java/com/grayzone/global/oauth/apple/AppleGenerateTokenResponseDto.java
@@ -1,0 +1,12 @@
+package com.grayzone.global.oauth.apple;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AppleGenerateTokenResponseDto {
+  @JsonProperty("refresh_token")
+  private String refreshToken;
+}

--- a/api/src/main/java/com/grayzone/global/oauth/apple/AppleOAuthTokenGenerator.java
+++ b/api/src/main/java/com/grayzone/global/oauth/apple/AppleOAuthTokenGenerator.java
@@ -1,0 +1,74 @@
+package com.grayzone.global.oauth.apple;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+import java.util.Date;
+
+@Slf4j
+@Component
+public class AppleOAuthTokenGenerator {
+  private final RestClient restClient = RestClient.create();
+
+  @Value("${apple.generate-token-uri}")
+  private String appleGenerateTokenUri;
+
+  @Value(("${apple.key-id}"))
+  private String appleKeyId;
+
+  @Value("${apple.client-id}")
+  private String appleClientId;
+
+  @Value("${apple.issuer-uri}")
+  private String appleAudience;
+
+  @Value("${apple.up-issuer-id}")
+  private String issuerId;
+
+  @Value("${apple.jwt-secret}")
+  private String appleJwtSecret;
+
+  public void generateAppleToken(String code) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+    MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+    body.add("grant_type", "authorization_code");
+    body.add("client_id", appleClientId);
+    body.add("client_secret", createClientSecret());
+    body.add("code", code);
+
+    restClient.post()
+      .uri(appleGenerateTokenUri)
+      .header("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+      .body(body)
+      .retrieve()
+      .body(String.class);
+  }
+
+  private String createClientSecret() {
+    Date now = new Date();
+    Date expiration = new Date(now.getTime() + 3600000);
+    String jwtSecret = appleJwtSecret.replace("\\n", "\n");
+
+    return Jwts.builder()
+      .header().add("alg", "ES256").and()
+      .header().add("kid", appleKeyId).and()
+      .issuer(issuerId)
+      .subject(appleClientId)
+      .audience().add(appleAudience).and()
+      .issuedAt(now)
+      .expiration(expiration)
+      .signWith(Keys.hmacShaKeyFor(jwtSecret.getBytes()))
+      .compact();
+  }
+
+}

--- a/api/src/main/java/com/grayzone/global/oauth/apple/AppleOAuthTokenGenerator.java
+++ b/api/src/main/java/com/grayzone/global/oauth/apple/AppleOAuthTokenGenerator.java
@@ -30,12 +30,16 @@ public class AppleOAuthTokenGenerator {
     body.add("client_secret", appleUtils.createClientSecret());
     body.add("code", code);
 
-    return restClient.post()
+    AppleTokenResponse response = restClient.post()
       .uri(appleGenerateTokenUri)
       .header("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE)
       .body(body)
       .retrieve()
       .body(AppleTokenResponse.class);
+
+    log.info(response.toString());
+
+    return response;
   }
 
 }

--- a/api/src/main/java/com/grayzone/global/oauth/apple/AppleOAuthTokenGenerator.java
+++ b/api/src/main/java/com/grayzone/global/oauth/apple/AppleOAuthTokenGenerator.java
@@ -4,7 +4,6 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
@@ -36,9 +35,7 @@ public class AppleOAuthTokenGenerator {
   @Value("${apple.jwt-secret}")
   private String appleJwtSecret;
 
-  public void generateAppleToken(String code) {
-    HttpHeaders headers = new HttpHeaders();
-    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+  public AppleGenerateTokenResponseDto generateAppleToken(String code) {
 
     MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
     body.add("grant_type", "authorization_code");
@@ -46,12 +43,12 @@ public class AppleOAuthTokenGenerator {
     body.add("client_secret", createClientSecret());
     body.add("code", code);
 
-    restClient.post()
+    return restClient.post()
       .uri(appleGenerateTokenUri)
       .header("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE)
       .body(body)
       .retrieve()
-      .body(String.class);
+      .body(AppleGenerateTokenResponseDto.class);
   }
 
   private String createClientSecret() {

--- a/api/src/main/java/com/grayzone/global/oauth/apple/AppleOAuthTokenGenerator.java
+++ b/api/src/main/java/com/grayzone/global/oauth/apple/AppleOAuthTokenGenerator.java
@@ -1,7 +1,6 @@
 package com.grayzone.global.oauth.apple;
 
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
@@ -10,37 +9,25 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 
-import java.util.Date;
-
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class AppleOAuthTokenGenerator {
   private final RestClient restClient = RestClient.create();
+  private final AppleUtils appleUtils;
 
   @Value("${apple.generate-token-uri}")
   private String appleGenerateTokenUri;
 
-  @Value(("${apple.key-id}"))
-  private String appleKeyId;
-
   @Value("${apple.client-id}")
   private String appleClientId;
 
-  @Value("${apple.issuer-uri}")
-  private String appleAudience;
-
-  @Value("${apple.up-issuer-id}")
-  private String issuerId;
-
-  @Value("${apple.jwt-secret}")
-  private String appleJwtSecret;
-
-  public AppleGenerateTokenResponseDto generateAppleToken(String code) {
+  public AppleTokenResponse generateAppleToken(String code) {
 
     MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
     body.add("grant_type", "authorization_code");
     body.add("client_id", appleClientId);
-    body.add("client_secret", createClientSecret());
+    body.add("client_secret", appleUtils.createClientSecret());
     body.add("code", code);
 
     return restClient.post()
@@ -48,24 +35,7 @@ public class AppleOAuthTokenGenerator {
       .header("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE)
       .body(body)
       .retrieve()
-      .body(AppleGenerateTokenResponseDto.class);
-  }
-
-  private String createClientSecret() {
-    Date now = new Date();
-    Date expiration = new Date(now.getTime() + 3600000);
-    String jwtSecret = appleJwtSecret.replace("\\n", "\n");
-
-    return Jwts.builder()
-      .header().add("alg", "ES256").and()
-      .header().add("kid", appleKeyId).and()
-      .issuer(issuerId)
-      .subject(appleClientId)
-      .audience().add(appleAudience).and()
-      .issuedAt(now)
-      .expiration(expiration)
-      .signWith(Keys.hmacShaKeyFor(jwtSecret.getBytes()))
-      .compact();
+      .body(AppleTokenResponse.class);
   }
 
 }

--- a/api/src/main/java/com/grayzone/global/oauth/apple/AppleOAuthUserInfoProvider.java
+++ b/api/src/main/java/com/grayzone/global/oauth/apple/AppleOAuthUserInfoProvider.java
@@ -57,9 +57,9 @@ public class AppleOAuthUserInfoProvider implements OAuthUserInfoProvider {
 
       verifyAppleIdTokenClaims(payload);
       String email = payload.get("email", String.class);
-      String id = payload.get("sub", String.class);
+      String oAuthid = payload.get("sub", String.class);
 
-      return new OAuthUserInfo(OAuthProvider.APPLE, email, id);
+      return new OAuthUserInfo(OAuthProvider.APPLE, email, oAuthid);
     } catch (Exception e) {
       throw new UpException(UpError.OAUTH_INVALID_TOKEN);
     }

--- a/api/src/main/java/com/grayzone/global/oauth/apple/AppleOAuthUserInfoProvider.java
+++ b/api/src/main/java/com/grayzone/global/oauth/apple/AppleOAuthUserInfoProvider.java
@@ -57,8 +57,9 @@ public class AppleOAuthUserInfoProvider implements OAuthUserInfoProvider {
 
       verifyAppleIdTokenClaims(payload);
       String email = payload.get("email", String.class);
+      String id = payload.get("sub", String.class);
 
-      return new OAuthUserInfo(OAuthProvider.APPLE, email);
+      return new OAuthUserInfo(OAuthProvider.APPLE, email, id);
     } catch (Exception e) {
       throw new UpException(UpError.OAUTH_INVALID_TOKEN);
     }

--- a/api/src/main/java/com/grayzone/global/oauth/apple/AppleRevokeService.java
+++ b/api/src/main/java/com/grayzone/global/oauth/apple/AppleRevokeService.java
@@ -4,6 +4,7 @@ import com.grayzone.domain.user.entity.User;
 import com.grayzone.global.oauth.OAuthProvider;
 import com.grayzone.global.oauth.OAuthRevokeService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +13,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AppleRevokeService implements OAuthRevokeService {

--- a/api/src/main/java/com/grayzone/global/oauth/apple/AppleRevokeService.java
+++ b/api/src/main/java/com/grayzone/global/oauth/apple/AppleRevokeService.java
@@ -6,6 +6,7 @@ import com.grayzone.global.oauth.OAuthRevokeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -40,11 +41,11 @@ public class AppleRevokeService implements OAuthRevokeService {
     body.add("token", refreshToken);
     body.add("token_type_hint", "refresh_token");
 
-    restClient.post()
+    ResponseEntity<Void> bodilessEntity = restClient.post()
       .uri(appleRevokeTokenUri)
       .header("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE)
       .body(body)
       .retrieve()
-      .body(String.class);
+      .toBodilessEntity();
   }
 }

--- a/api/src/main/java/com/grayzone/global/oauth/apple/AppleRevokeService.java
+++ b/api/src/main/java/com/grayzone/global/oauth/apple/AppleRevokeService.java
@@ -1,8 +1,9 @@
-package com.grayzone.global.oauth.kakao;
+package com.grayzone.global.oauth.apple;
 
 import com.grayzone.domain.user.entity.User;
 import com.grayzone.global.oauth.OAuthProvider;
 import com.grayzone.global.oauth.OAuthRevokeService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -11,32 +12,37 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 
 @Component
-public class KakaoRevokeService implements OAuthRevokeService {
+@RequiredArgsConstructor
+public class AppleRevokeService implements OAuthRevokeService {
+
   private final RestClient restClient = RestClient.create();
+  private final AppleUtils appleUtils;
 
-  @Value("${kakao.app-admin-key}")
-  private String kakaoAdminKey;
+  @Value("${apple.revoke-token-uri}")
+  private String appleRevokeTokenUri;
 
-  @Value("${kakao.revoke-uri}")
-  private String kakaoRevokeUri;
+  @Value("${apple.client-id}")
+  private String appleClientId;
 
   @Override
   public boolean support(OAuthProvider provider) {
-    return provider == OAuthProvider.KAKAO;
+    return provider == OAuthProvider.APPLE;
   }
 
   @Override
   public void revoke(User user) {
-    String oAuthId = user.getOAuthId();
+    String clientSecret = appleUtils.createClientSecret();
+    String refreshToken = user.getOAuthRefreshToken();
 
     MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-    body.add("target_id_type", "user_id");
-    body.add("target_id", oAuthId);
+    body.add("client_id", appleClientId);
+    body.add("client_secret", clientSecret);
+    body.add("token", refreshToken);
+    body.add("token_type_hint", "refresh_token");
 
     restClient.post()
-      .uri(kakaoRevokeUri)
+      .uri(appleRevokeTokenUri)
       .header("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-      .header("Authorization", kakaoAdminKey)
       .body(body)
       .retrieve()
       .body(String.class);

--- a/api/src/main/java/com/grayzone/global/oauth/apple/AppleTokenResponse.java
+++ b/api/src/main/java/com/grayzone/global/oauth/apple/AppleTokenResponse.java
@@ -6,7 +6,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class AppleGenerateTokenResponseDto {
+public class AppleTokenResponse {
   @JsonProperty("refresh_token")
   private String refreshToken;
 }

--- a/api/src/main/java/com/grayzone/global/oauth/apple/AppleUtils.java
+++ b/api/src/main/java/com/grayzone/global/oauth/apple/AppleUtils.java
@@ -1,0 +1,44 @@
+package com.grayzone.global.oauth.apple;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class AppleUtils {
+
+  @Value(("${apple.key-id}"))
+  private String appleKeyId;
+
+  @Value("${apple.client-id}")
+  private String appleClientId;
+
+  @Value("${apple.issuer-uri}")
+  private String appleAudience;
+
+  @Value("${apple.up-issuer-id}")
+  private String issuerId;
+
+  @Value("${apple.jwt-secret}")
+  private String appleJwtSecret;
+
+  public String createClientSecret() {
+    Date now = new Date();
+    Date expiration = new Date(now.getTime() + 3600000);
+    String jwtSecret = appleJwtSecret.replace("\\n", "\n");
+
+    return Jwts.builder()
+      .header().add("alg", "ES256").and()
+      .header().add("kid", appleKeyId).and()
+      .issuer(issuerId)
+      .subject(appleClientId)
+      .audience().add(appleAudience).and()
+      .issuedAt(now)
+      .expiration(expiration)
+      .signWith(Keys.hmacShaKeyFor(jwtSecret.getBytes()))
+      .compact();
+  }
+}

--- a/api/src/main/java/com/grayzone/global/oauth/apple/AppleUtils.java
+++ b/api/src/main/java/com/grayzone/global/oauth/apple/AppleUtils.java
@@ -1,10 +1,15 @@
 package com.grayzone.global.oauth.apple;
 
+import com.grayzone.global.exception.UpError;
+import com.grayzone.global.exception.UpException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
+import org.apache.tomcat.util.codec.binary.Base64;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Date;
 
 @Component
@@ -27,8 +32,7 @@ public class AppleUtils {
 
   public String createClientSecret() {
     Date now = new Date();
-    Date expiration = new Date(now.getTime() + 3600000);
-    String jwtSecret = appleJwtSecret.replace("\\n", "\n");
+    Date expiration = new Date(now.getTime() + 60L * 60 * 24 * 30 * 2 * 1000);
 
     return Jwts.builder()
       .header().add("alg", "ES256").and()
@@ -38,7 +42,25 @@ public class AppleUtils {
       .audience().add(appleAudience).and()
       .issuedAt(now)
       .expiration(expiration)
-      .signWith(Keys.hmacShaKeyFor(jwtSecret.getBytes()))
+      .signWith(getPrivateKey())
       .compact();
   }
+
+  private PrivateKey getPrivateKey() {
+    String jwtSecret = appleJwtSecret.replace("\\n", "\n");
+
+    try {
+      byte[] encoded = Base64.decodeBase64(jwtSecret);
+      PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(encoded);
+
+      KeyFactory keyFactory = KeyFactory.getInstance("EC");
+      return keyFactory.generatePrivate(keySpec);
+    } catch (Exception e) {
+      throw new UpException(UpError.SERVER_ERROR);
+    }
+  }
 }
+
+
+
+

--- a/api/src/main/java/com/grayzone/global/oauth/kakao/KakaoOAuthUserInfoProvider.java
+++ b/api/src/main/java/com/grayzone/global/oauth/kakao/KakaoOAuthUserInfoProvider.java
@@ -33,6 +33,6 @@ public class KakaoOAuthUserInfoProvider implements OAuthUserInfoProvider {
       throw new UpException(UpError.OAUTH_INVALID_TOKEN);
     }
 
-    return new OAuthUserInfo(OAuthProvider.KAKAO, kakaoUserInfo.getEmail());
+    return new OAuthUserInfo(OAuthProvider.KAKAO, kakaoUserInfo.getEmail(), kakaoUserInfo.getId().toString());
   }
 }

--- a/api/src/main/java/com/grayzone/global/oauth/kakao/KakaoOAuthUserInfoProvider.java
+++ b/api/src/main/java/com/grayzone/global/oauth/kakao/KakaoOAuthUserInfoProvider.java
@@ -5,10 +5,12 @@ import com.grayzone.global.exception.UpException;
 import com.grayzone.global.oauth.OAuthProvider;
 import com.grayzone.global.oauth.OAuthUserInfo;
 import com.grayzone.global.oauth.OAuthUserInfoProvider;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
+@Slf4j
 @Component
 public class KakaoOAuthUserInfoProvider implements OAuthUserInfoProvider {
   private final RestClient restClient = RestClient.create();
@@ -32,6 +34,8 @@ public class KakaoOAuthUserInfoProvider implements OAuthUserInfoProvider {
     if (!kakaoUserInfo.isEmailVerified() && !kakaoUserInfo.isEmailValid()) {
       throw new UpException(UpError.OAUTH_INVALID_TOKEN);
     }
+
+    log.info("kakao user id {}", kakaoUserInfo.getId());
 
     return new OAuthUserInfo(OAuthProvider.KAKAO, kakaoUserInfo.getEmail(), kakaoUserInfo.getId().toString());
   }

--- a/api/src/main/java/com/grayzone/global/oauth/kakao/KakaoOAuthUserInfoProvider.java
+++ b/api/src/main/java/com/grayzone/global/oauth/kakao/KakaoOAuthUserInfoProvider.java
@@ -35,8 +35,6 @@ public class KakaoOAuthUserInfoProvider implements OAuthUserInfoProvider {
       throw new UpException(UpError.OAUTH_INVALID_TOKEN);
     }
 
-    log.info("kakao user id {}", kakaoUserInfo.getId());
-
     return new OAuthUserInfo(OAuthProvider.KAKAO, kakaoUserInfo.getEmail(), kakaoUserInfo.getId().toString());
   }
 }

--- a/api/src/main/java/com/grayzone/global/oauth/kakao/KakaoRevokeService.java
+++ b/api/src/main/java/com/grayzone/global/oauth/kakao/KakaoRevokeService.java
@@ -1,0 +1,43 @@
+package com.grayzone.global.oauth.kakao;
+
+import com.grayzone.domain.user.entity.User;
+import com.grayzone.global.oauth.OAuthProvider;
+import com.grayzone.global.oauth.OAuthRevokeService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class KakaoRevokeService implements OAuthRevokeService {
+  private final RestClient restClient = RestClient.create();
+
+  @Value("${kakao.app-admin-key}")
+  private String kakaoAdminKey;
+
+  @Value("${kakao.revoke-uri}")
+  private String kakaoRevokeUri;
+
+  @Override
+  public boolean support(OAuthProvider provider) {
+    return provider == OAuthProvider.KAKAO;
+  }
+
+  @Override
+  public void revoke(User user) {
+    String oAuthId = user.getOAuthId();
+
+    MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+    body.add("target_id_type", "user_id");
+    body.add("target_id", oAuthId);
+
+    restClient.post()
+      .uri(kakaoRevokeUri)
+      .header("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+      .body(body)
+      .retrieve()
+      .body(String.class);
+  }
+}

--- a/api/src/main/java/com/grayzone/global/oauth/kakao/KakaoUserInfoResponse.java
+++ b/api/src/main/java/com/grayzone/global/oauth/kakao/KakaoUserInfoResponse.java
@@ -7,6 +7,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class KakaoUserInfoResponse {
+  private Long id;
   @JsonProperty("kakao_account")
   private KakaoAccount kakaoAccount;
 

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -25,8 +25,12 @@ legal.district.api.key=${LEGAL_DISTRICT_API_KEY}
 kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
 # Apple OAuth
 apple.public-key-uri=https://appleid.apple.com/auth/keys
+apple.generate-token-uri=https://appleid.apple.com/auth/token
 apple.issuer-uri=https://appleid.apple.com
 apple.client-id=${APPLE_BUNDLE_ID}
+apple.key-id=${APPLE_KEY_ID}
+apple.up-issuer-id=${UP_ISSUER_ID}
+apple.jwt-secret=${APPLE_JWT_SECRET}
 # JWT
 jwt.secret=${JWT_SECRET}
 # Admin

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -23,6 +23,8 @@ legal.district.api.path=/15063424/v1/uddi:6d7fd177-cc7d-426d-ba80-9b137edf6066
 legal.district.api.key=${LEGAL_DISTRICT_API_KEY}
 # Kakao OAuth
 kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
+kakao.revoke-uri=https://kapi.kakao.com/v1/user/unlink
+kakao.app-admin-key=${KAKAO_APP_ADMIN_KEY}
 # Apple OAuth
 apple.public-key-uri=https://appleid.apple.com/auth/keys
 apple.generate-token-uri=https://appleid.apple.com/auth/token

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -28,6 +28,7 @@ kakao.app-admin-key=${KAKAO_APP_ADMIN_KEY}
 # Apple OAuth
 apple.public-key-uri=https://appleid.apple.com/auth/keys
 apple.generate-token-uri=https://appleid.apple.com/auth/token
+apple.revoke-token-uri=https://appleid.apple.com/auth/revoke
 apple.issuer-uri=https://appleid.apple.com
 apple.client-id=${APPLE_BUNDLE_ID}
 apple.key-id=${APPLE_KEY_ID}


### PR DESCRIPTION
## 🔍 관련 GitHub 이슈

- closed #55

## 📝 변경 사항
- 로그인 api 요청 변경
- 회원가입 api 회원탈퇴 로직 구현

## 📸 스크린샷

## ✅ PR 체크리스트

- [x] 커밋 메시지에 GitHub 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] GitHub 이슈 상태 업데이트

## 📌 참고 사항

- 
