### PR TITLE
[#54] GitHub actions docker cache 설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - config/*
 
 jobs:
   ssh-agent:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Cache Docker Image Layer
         uses: actions/cache@v4.2.0
         with:
-          path: /tmp/.buildx-cache # 캐시로 관리할 경로
+          path: /tmp/.build-cache # 캐시로 관리할 경로
           key: docker-image-layer-cache-${{ github.sha }} # 저장 & 불러올 캐시 이름(식별자)
           restore-keys: docker-image-layer-cache- # 만약 캐시 key를 찾지 못하면 대체할 캐시 이름
       

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - config/*
 
 jobs:
   ssh-agent:
@@ -37,6 +38,7 @@ jobs:
       - name: Create BuildKit 빌더
         run: |
           docker buildx create --use --name buildkit
+          docker buildx use buildkit
       
       - name: Docker Image Build
         run: docker compose -f docker-compose-production.yml build --build-arg BUILDKIT_INLINE_CACHE=1

--- a/api/src/main/java/com/grayzone/domain/review/dto/request/CreateReviewCommentRequestDto.java
+++ b/api/src/main/java/com/grayzone/domain/review/dto/request/CreateReviewCommentRequestDto.java
@@ -19,7 +19,6 @@ public class CreateReviewCommentRequestDto {
   private boolean isSecret;
 
   public ReviewComment toEntity(CompanyReview companyReview, User user) {
-    System.out.println(isSecret);
     return ReviewComment.builder()
       .comment(comment)
       .isSecret(isSecret)

--- a/api/src/main/java/com/grayzone/domain/review/service/CompanyReviewService.java
+++ b/api/src/main/java/com/grayzone/domain/review/service/CompanyReviewService.java
@@ -139,8 +139,6 @@ public class CompanyReviewService {
 
     String title = reviewTitleSummarizer.summarize(requestDto.getSummarizeSourceText());
 
-    log.info("gemini summarized title: {}", title);
-
     CompanyReview companyReview = requestDto.toCompanyReview(company, user, title);
     companyReviewRepository.save(companyReview);
 


### PR DESCRIPTION
## 🔍 관련 GitHub 이슈

- closed #54 

## 📝 변경 사항
- Github actions docker image cache 설정

## 📸 스크린샷

## ✅ PR 체크리스트

- [x] 커밋 메시지에 GitHub 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] GitHub 이슈 상태 업데이트

## 📌 참고 사항

- 
