### PR TITLE
[#63] 회원탈퇴 api 로직 수정

### DIFF
--- a/api/src/main/java/com/grayzone/domain/review/entity/CompanyReview.java
+++ b/api/src/main/java/com/grayzone/domain/review/entity/CompanyReview.java
@@ -37,7 +37,7 @@ public class CompanyReview extends BaseTimeEntity {
   private Company company;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_id", nullable = true)
+  @JoinColumn(name = "user_id")
   private User user;
 
   @OneToMany(mappedBy = "companyReview", fetch = FetchType.LAZY)

--- a/api/src/main/java/com/grayzone/domain/user/entity/User.java
+++ b/api/src/main/java/com/grayzone/domain/user/entity/User.java
@@ -41,7 +41,7 @@ public class User implements UserDetails {
   private List<InterestedRegion> interestedRegions = new ArrayList<>();
 
   @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<FollowCompany> followCompanies;
+  private List<FollowCompany> followCompanies = new ArrayList<>();
 
   private boolean agreedServiceUse;
   private boolean agreedPrivacy;
@@ -94,5 +94,16 @@ public class User implements UserDetails {
 
   public boolean requiresAppleRefreshToken() {
     return this.oAuthProvider == OAuthProvider.APPLE && this.oAuthRefreshToken == null;
+  }
+
+  public void inactive() {
+    setNickname("deleted_user_" + this.id);
+    setEmail(null);
+    setOAuthId(null);
+    setOAuthRefreshToken(null);
+    setMainRegion(null);
+    setOAuthProvider(OAuthProvider.INACTIVE);
+    this.interestedRegions.clear();
+    this.followCompanies.clear();
   }
 }

--- a/api/src/main/java/com/grayzone/domain/user/service/UserService.java
+++ b/api/src/main/java/com/grayzone/domain/user/service/UserService.java
@@ -103,6 +103,7 @@ public class UserService {
       log.warn("OAuth revoke dispatch failed", e);
     }
 
-    userRepository.delete(deletedUser);
+    deletedUser.inactive();
+    userRepository.save(deletedUser);
   }
 }

--- a/api/src/main/java/com/grayzone/global/oauth/OAuthProvider.java
+++ b/api/src/main/java/com/grayzone/global/oauth/OAuthProvider.java
@@ -9,7 +9,8 @@ import lombok.extern.slf4j.Slf4j;
 public enum OAuthProvider {
   KAKAO,
   APPLE,
-  ADMIN;
+  ADMIN,
+  INACTIVE;
 
   @JsonCreator
   public static OAuthProvider from(String name) {


### PR DESCRIPTION
## 🔍 관련 GitHub 이슈

- closed #63 

## 📝 변경 사항
- 회원 탈퇴 로직을 User를 inactive 하는 방향으로 수정

## 📸 스크린샷

## ✅ PR 체크리스트

- [ ] 커밋 메시지에 GitHub 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [ ] GitHub 이슈 상태 업데이트

## 📌 참고 사항

- 
